### PR TITLE
feat: add applicant form pages, components, and API setup

### DIFF
--- a/src/app/applicant/application/coding-profiles/page.tsx
+++ b/src/app/applicant/application/coding-profiles/page.tsx
@@ -1,0 +1,126 @@
+"use client";
+
+import { useRouter } from "next/navigation";
+import { Input } from "@/app/components/input";
+import Button from "@/app/components/Button";
+import { Progress } from "@/app/components/progress";
+import { Label } from "@/app/components/label";
+import { useApplicationForm } from "@/lib/context/ApplicationFormContext";
+
+export default function CodingProfilesStep() {
+  const router = useRouter();
+  const { formData, updateFormData } = useApplicationForm(); // ✅ get form state
+
+  const handleChange = (e: React.ChangeEvent<HTMLInputElement>) => {
+    const { name, value } = e.target;
+    updateFormData({ [name]: value }); // ✅ update context instead of local state
+  };
+
+  const handleNext = () => {
+    router.push("/applicant/application/essays-resume");
+  };
+
+  const handleBack = () => {
+    router.push("/applicant/application/personal-info");
+  };
+
+  return (
+    <div className="min-h-screen bg-[#f5f6fa] flex items-center justify-center p-6">
+      {/* <HeaderForApplicantForm /> */}
+      <form className="bg-white rounded-xl border border-gray-200 shadow-sm w-full max-w-2xl p-6 space-y-6">
+        <h2 className="text-center text-xl font-semibold">Application Form</h2>
+
+        {/* Progress Bar */}
+        <Progress step={2} value={66} className="h-1 bg-gray-200 mb-4" />
+
+        {/* Stepper */}
+        <div className="flex justify-around border-b border-gray-200 pb-4 text-sm font-medium">
+          <div className="flex items-center gap-2 text-[#5f3dc4]">
+            <span className="w-6 h-6 rounded-full bg-[#e0dbfa] text-[#5f3dc4] text-xs flex items-center justify-center">
+              1
+            </span>
+            <span>Personal Info</span>
+          </div>
+          <div className="flex items-center gap-2 text-[#5f3dc4] font-medium">
+            <span className="w-6 h-6 rounded-full bg-[#5f3dc4] text-white text-xs flex items-center justify-center">
+              2
+            </span>
+            <span>Coding Profiles</span>
+          </div>
+          <div className="flex items-center gap-2 text-gray-400">
+            <span className="w-6 h-6 rounded-full bg-gray-200 text-xs flex items-center justify-center">
+              3
+            </span>
+            <span>Essays & Resume</span>
+          </div>
+        </div>
+
+        {/* Coding Profile Inputs */}
+        <div className="space-y-4">
+          <h3 className="text-base font-semibold text-gray-800">
+            Coding Profiles
+          </h3>
+
+          <div className="grid grid-cols-1 md:grid-cols-2 gap-4">
+            <div className="space-y-4">
+              <Label htmlFor="codeforces">Codeforces</Label>
+              <Input
+                id="codeforces"
+                name="codeforces"
+                value={formData.codeforces || ""}
+                onChange={handleChange}
+                className="bg-white"
+                placeholder="Enter your Codeforces profile"
+              />
+            </div>
+
+            <div className="space-y-4">
+              <Label htmlFor="leetcode">LeetCode</Label>
+              <Input
+                id="leetcode"
+                name="leetcode"
+                value={formData.leetcode || ""}
+                onChange={handleChange}
+                className="bg-white"
+                placeholder="Enter your LeetCode profile"
+              />
+            </div>
+          </div>
+
+          <div className="space-y-4">
+            <Label htmlFor="github">Github</Label>
+            <Input
+              id="github"
+              name="github"
+              value={formData.github || ""}
+              onChange={handleChange}
+              className="bg-white"
+              placeholder="Enter your Github profile"
+            />
+          </div>
+        </div>
+
+        {/* Navigation Buttons */}
+        <div className="flex justify-between border-t pt-4">
+          <Button
+            type="button"
+            variant="secondary"
+            size="small"
+            className="bg-gray-100 text-gray-800 px-3 py-1.5 text-sm rounded-md"
+            onClick={handleBack}
+          >
+            Back
+          </Button>
+          <Button
+            type="button"
+            size="applicantForm"
+            onClick={handleNext}
+            className="bg-[#5f3dc4] hover:bg-[#5032ad] text-white px-3 py-1.5 text-sm rounded-md"
+          >
+            Next: Essay and Resume
+          </Button>
+        </div>
+      </form>
+    </div>
+  );
+}

--- a/src/app/applicant/application/essays-resume/page.tsx
+++ b/src/app/applicant/application/essays-resume/page.tsx
@@ -1,0 +1,254 @@
+"use client";
+
+import { useState } from "react";
+import { useRouter } from "next/navigation";
+import { Input } from "@/app/components/input";
+import { Label } from "@/app/components/label";
+import { Progress } from "@/app/components/progress";
+import { Textarea } from "@/app/components/textarea";
+import Button from "@/app/components/Button";
+import Toaster from "@/app/components/Toaster";
+
+import { useApplicationForm } from "@/lib/context/ApplicationFormContext";
+import { useSubmitApplicationMutation } from "@/lib/redux/api/applicationApi";
+
+export default function EssaysResumeStep() {
+  const router = useRouter();
+  const { formData, updateFormData } = useApplicationForm();
+  const [resumeFile, setResumeFile] = useState<File | null>(null);
+  const [submitApplication, { isLoading }] = useSubmitApplicationMutation();
+
+  const [errorMessages, setErrorMessages] = useState<string[]>([]);
+
+  const [toast, setToast] = useState<{
+    message: string;
+    type: "success" | "error";
+    show: boolean;
+  }>({
+    message: "",
+    type: "success",
+    show: false,
+  });
+
+  const handleResumeChange = (e: React.ChangeEvent<HTMLInputElement>) => {
+    if (e.target.files && e.target.files.length > 0) {
+      setResumeFile(e.target.files[0]);
+    }
+  };
+
+  const handleSubmit = async () => {
+    const errors: string[] = [];
+
+    if (!formData.university) errors.push("University (school) is required.");
+    if (!formData.id_number) errors.push("Student ID is required.");
+    if (!formData.degree) errors.push("Degree is required.");
+    if (!formData.country) errors.push("Country is required.");
+    if (!formData.leetcode) errors.push("LeetCode handle is required.");
+    if (!formData.codeforces) errors.push("Codeforces handle is required.");
+    if (!formData.essay_question_1)
+      errors.push("Essay about yourself is required.");
+    if (!formData.essay_question_2)
+      errors.push("Essay about why you want to join is required.");
+    if (!resumeFile) errors.push("Resume file is required.");
+
+    if (errors.length > 0) {
+      setErrorMessages(errors);
+      return;
+    }
+
+    setErrorMessages([]);
+
+    const payload = new FormData();
+    payload.append("school", formData.university ?? "");
+    payload.append("student_id", formData.id_number ?? "");
+    payload.append("degree", formData.degree ?? "");
+    payload.append("country", formData.country ?? "Ethiopia");
+    payload.append("leetcode_handle", formData.leetcode ?? "");
+    payload.append("codeforces_handle", formData.codeforces ?? "");
+    payload.append("essay_about_you", formData.essay_question_1 ?? "");
+    payload.append("essay_why_a2sv", formData.essay_question_2 ?? "");
+    if (resumeFile) payload.append("resume", resumeFile);
+
+    try {
+      await submitApplication(payload).unwrap();
+
+      setToast({
+        message:
+          "Application submitted successfully! You will be redirected to the dashboard page.",
+        type: "success",
+        show: true,
+      });
+
+      // ✅ Redirect to dashboard after short delay
+      setTimeout(() => {
+        router.push("applicant/dashboard"); // 🔁 Change if your dashboard route is different
+      }, 1500);
+    } catch (err: any) {
+      console.error("Submission failed:", err);
+
+      if (err?.data?.message) {
+        setToast({
+          message: err.data.message,
+          type: "error",
+          show: true,
+        });
+      } else if (err?.status === 409) {
+        setToast({
+          message: "You have already submitted an application.",
+          type: "error",
+          show: true,
+        });
+      } else {
+        setToast({
+          message: "Something went wrong. Please try again.",
+          type: "error",
+          show: true,
+        });
+      }
+    }
+  };
+
+  const handleBack = () => {
+    router.push("/applicant/application/coding-profiles");
+  };
+
+  return (
+    <div className="min-h-screen bg-[#f5f6fa] flex items-center justify-center px-4 py-8">
+      {/* ✅ Toaster */}
+      <Toaster
+        message={toast.message}
+        type={toast.type}
+        show={toast.show}
+        onClose={() => setToast({ ...toast, show: false })}
+      />
+
+      <form
+        className="bg-white shadow-md rounded-xl border w-full max-w-xl p-6"
+        onSubmit={(e) => {
+          e.preventDefault();
+          handleSubmit();
+        }}
+      >
+        <h2 className="text-center text-lg font-semibold mb-6">
+          Application Form
+        </h2>
+        <Progress step={3} value={100} className="h-1 bg-gray-200 mb-4" />
+
+        {/* Stepper */}
+        <div className="flex justify-around border-b border-gray-200 pb-4 text-sm font-medium">
+          <div className="flex items-center gap-2 text-[#5f3dc4]">
+            <span className="w-6 h-6 rounded-full bg-[#e0dbfa] text-[#5f3dc4] text-xs flex items-center justify-center">
+              1
+            </span>
+            <span>Personal Info</span>
+          </div>
+          <div className="flex items-center gap-2 text-[#5f3dc4]">
+            <span className="w-6 h-6 rounded-full bg-[#e0dbfa] text-[#5f3dc4] text-xs flex items-center justify-center">
+              2
+            </span>
+            <span>Coding Profiles</span>
+          </div>
+          <div className="flex items-center gap-2 text-gray-400">
+            <span className="w-6 h-6 rounded-full bg-[#5f3dc4] text-white text-xs flex items-center justify-center">
+              3
+            </span>
+            <span>Essays & Resume</span>
+          </div>
+        </div>
+
+        {/* Validation Errors */}
+        {errorMessages.length > 0 && (
+          <div className="bg-red-100 border border-red-400 text-red-700 px-4 py-2 rounded mt-4">
+            <ul className="list-disc list-inside text-sm">
+              {errorMessages.map((err, i) => (
+                <li key={i}>{err}</li>
+              ))}
+            </ul>
+          </div>
+        )}
+
+        {/* Essay Questions */}
+        <div className="space-y-4 mt-4">
+          <div className="space-y-4">
+            <Label
+              htmlFor="essay_question_1"
+              className="text-gray-700 font-medium"
+            >
+              Tell us about yourself.
+            </Label>
+            <Textarea
+              id="essay_question_1"
+              name="essay_question_1"
+              rows={4}
+              value={formData.essay_question_1}
+              onChange={(e) =>
+                updateFormData({ essay_question_1: e.target.value })
+              }
+              placeholder="Write your answer here..."
+              className="mt-1 border border-[#E0E0E0] focus:border-[#5f3dc4] focus:ring-[#e0dbfa] rounded-md shadow-sm"
+            />
+          </div>
+
+          <div className="space-y-4">
+            <Label
+              htmlFor="essay_question_2"
+              className="text-gray-700 font-medium"
+            >
+              Why do you want to join us?
+            </Label>
+            <Textarea
+              id="essay_question_2"
+              name="essay_question_2"
+              rows={4}
+              value={formData.essay_question_2}
+              onChange={(e) =>
+                updateFormData({ essay_question_2: e.target.value })
+              }
+              placeholder="Write your answer here..."
+              className="mt-1 border border-[#E0E0E0] focus:border-[#5f3dc4] focus:ring-[#e0dbfa] rounded-md shadow-sm"
+            />
+          </div>
+        </div>
+
+        {/* Resume Upload */}
+        <div className="mt-6 space-y-4">
+          <Label htmlFor="resume" className="text-gray-700 font-medium">
+            Resume
+          </Label>
+          <p className="text-sm text-gray-500 mb-1">Upload your resume</p>
+          <Input
+            id="resume"
+            type="file"
+            accept=".pdf"
+            onChange={handleResumeChange}
+            className="bg-white"
+          />
+          {!resumeFile && (
+            <p className="text-xs text-red-500 mt-1">* No file chosen</p>
+          )}
+        </div>
+
+        {/* Action Buttons */}
+        <div className="mt-6 flex justify-between">
+          <Button
+            type="button"
+            variant="secondary"
+            size="small"
+            className="bg-gray-100 text-gray-800 px-3 py-1.5 text-sm rounded-md"
+            onClick={handleBack}
+          >
+            Back
+          </Button>
+          <Button
+            type="submit"
+            size="applicantForm"
+            className="bg-[#5f3dc4] hover:bg-[#5032ad] text-white px-6 py-2 rounded-md"
+            disabled={isLoading}
+          >
+            {isLoading ? "Submitting..." : "Submit"}
+          </Button>
+        </div>
+      </form>
+    </div>
+  );
+}

--- a/src/app/applicant/application/personal-info/page.tsx
+++ b/src/app/applicant/application/personal-info/page.tsx
@@ -1,0 +1,130 @@
+"use client";
+
+import { useRouter } from "next/navigation";
+import { Input } from "@/app/components/input";
+import Button from "@/app/components/Button";
+import { Progress } from "@/app/components/progress";
+import { Label } from "@/app/components/label";
+import { useApplicationForm } from "@/lib/context/ApplicationFormContext";
+
+export default function PersonalInfoStep() {
+  const router = useRouter();
+  const { formData, updateFormData } = useApplicationForm();
+
+  const handleNext = () => {
+    router.push("/applicant/application/coding-profiles");
+  };
+
+  return (
+    <div className="min-h-screen bg-[#f5f6fa] flex items-center justify-center p-6">
+      <form className="bg-white rounded-xl border border-gray-200 shadow-sm w-full max-w-2xl p-6 space-y-6">
+        <h2 className="text-center text-xl font-semibold">Application Form</h2>
+
+        {/* Progress bar */}
+        <Progress step={1} value={33} className="h-1 bg-gray-200 mb-4" />
+
+        {/* Stepper */}
+        <div className="flex justify-around border-b border-gray-200 pb-4 text-sm font-medium">
+          <div className="flex items-center gap-2 text-[#5f3dc4]">
+            <span className="w-6 h-6 rounded-full bg-[#5f3dc4] text-white text-xs flex items-center justify-center">
+              1
+            </span>
+            <span>Personal Info</span>
+          </div>
+          <div className="flex items-center gap-2 text-gray-400">
+            <span className="w-6 h-6 rounded-full bg-gray-200 text-xs flex items-center justify-center">
+              2
+            </span>
+            <span>Coding Profiles</span>
+          </div>
+          <div className="flex items-center gap-2 text-gray-400">
+            <span className="w-6 h-6 rounded-full bg-gray-200 text-xs flex items-center justify-center">
+              3
+            </span>
+            <span>Essays & Resume</span>
+          </div>
+        </div>
+
+        {/* Inputs */}
+        <div className="space-y-4">
+          <h3 className="text-base font-semibold text-gray-800">
+            Personal Information
+          </h3>
+
+          <div className="grid grid-cols-1 md:grid-cols-2 gap-4">
+            <div className="flex flex-col space-y-2">
+              <Label htmlFor="id_number">ID Number</Label>
+              <Input
+                id="id_number"
+                name="id_number"
+                value={formData.id_number || ""}
+                onChange={(e) => updateFormData({ id_number: e.target.value })}
+                className="bg-white"
+                placeholder="Enter your ID number"
+              />
+            </div>
+            <div className="flex flex-col space-y-2">
+              <Label htmlFor="university">School / University</Label>
+              <Input
+                id="university"
+                name="university"
+                value={formData.university || ""}
+                onChange={(e) => updateFormData({ university: e.target.value })}
+                className="bg-white"
+                placeholder="Enter your university"
+              />
+            </div>
+          </div>
+
+          {/* Degree and Country side-by-side */}
+          <div className="grid grid-cols-1 md:grid-cols-2 gap-4">
+            <div className="flex flex-col space-y-2">
+              <Label htmlFor="degree_program">Degree Program</Label>
+              <Input
+                id="degree_program"
+                name="degree_program"
+                value={formData.degree || ""}
+                onChange={(e) => updateFormData({ degree: e.target.value })}
+                className="bg-white"
+                placeholder="Enter your degree program"
+              />
+            </div>
+            <div className="flex flex-col space-y-2">
+              <Label htmlFor="country">Country</Label>
+              <Input
+                id="country"
+                name="country"
+                value={formData.country || ""}
+                onChange={(e) => updateFormData({ country: e.target.value })}
+                className="bg-white"
+                placeholder="Enter your country"
+              />
+            </div>
+          </div>
+        </div>
+
+        {/* Buttons */}
+        <div className="flex justify-between border-t pt-4">
+          <Button
+            type="button"
+            variant="secondary"
+            size="small"
+            className="bg-gray-100 text-gray-800 px-3 py-1.5 text-sm rounded-md"
+            onClick={() => router.back()}
+          >
+            Back
+          </Button>
+
+          <Button
+            type="button"
+            size="applicantForm"
+            onClick={handleNext}
+            className="bg-[#5f3dc4] hover:bg-[#5032ad] text-white px-3 py-1.5 text-sm rounded-md"
+          >
+            Next: Coding Profiles
+          </Button>
+        </div>
+      </form>
+    </div>
+  );
+}

--- a/src/app/components/Button.tsx
+++ b/src/app/components/Button.tsx
@@ -2,7 +2,7 @@ import React from "react";
 
 interface ButtonProps extends React.ButtonHTMLAttributes<HTMLButtonElement> {
   variant?: "primary" | "secondary";
-  size?: "xsmall" | "small" | "default" | "medium"; // Added new sizes
+  size?: "xsmall" | "small" | "default" | "medium" | "applicantForm"; // 👈 Added new size
 }
 
 const Button: React.FC<ButtonProps> = ({
@@ -26,6 +26,10 @@ const Button: React.FC<ButtonProps> = ({
     case "medium":
       baseStyle =
         "max-w-[150px] px-5 py-1 rounded-md text-base font-medium focus:outline-none focus:ring-2 focus:ring-offset-2 transition";
+      break;
+    case "applicantForm":
+      baseStyle =
+        "w-[160px] px-4 py-1.5 rounded-md text-sm font-medium focus:outline-none focus:ring-2 focus:ring-offset-2 transition";
       break;
     default:
       baseStyle =

--- a/src/app/components/Card.tsx
+++ b/src/app/components/Card.tsx
@@ -1,0 +1,48 @@
+import * as React from "react";
+
+import { cn } from "@/lib/utils";
+
+type CardProps = React.HTMLAttributes<HTMLDivElement>;
+
+function Card({ className, ...props }: CardProps) {
+  return (
+    <div
+      className={cn(
+        "bg-white border border-gray-200 rounded-lg shadow-sm",
+        className
+      )}
+      {...props}
+    />
+  );
+}
+
+function CardHeader({
+  className,
+  ...props
+}: React.HTMLAttributes<HTMLDivElement>) {
+  return (
+    <div
+      className={cn(
+        "px-6 py-4 border-b border-gray-200 text-center",
+        className
+      )}
+      {...props}
+    />
+  );
+}
+
+function CardTitle({
+  className,
+  ...props
+}: React.HTMLAttributes<HTMLHeadingElement>) {
+  return <h3 className={cn("text-xl font-bold", className)} {...props} />;
+}
+
+function CardContent({
+  className,
+  ...props
+}: React.HTMLAttributes<HTMLDivElement>) {
+  return <div className={cn("px-6 py-6", className)} {...props} />;
+}
+
+export { Card, CardHeader, CardTitle, CardContent };

--- a/src/app/components/Input.tsx
+++ b/src/app/components/Input.tsx
@@ -1,0 +1,23 @@
+import * as React from "react";
+
+import { cn } from "@/lib/utils";
+
+export const Input = React.forwardRef<
+  HTMLInputElement,
+  React.InputHTMLAttributes<HTMLInputElement>
+>(({ className, ...props }, ref) => {
+  return (
+    <input
+      ref={ref}
+      className={cn(
+        "w-full px-3 py-2 text-sm border border-gray-300 rounded-md shadow-sm",
+        "focus:outline-none focus:ring-2 focus:ring-purple-500 focus:border-purple-500",
+        "placeholder-gray-400",
+        className
+      )}
+      {...props}
+    />
+  );
+});
+
+Input.displayName = "Input";

--- a/src/app/components/Label.tsx
+++ b/src/app/components/Label.tsx
@@ -1,0 +1,24 @@
+"use client"
+
+import * as React from "react"
+import * as LabelPrimitive from "@radix-ui/react-label"
+
+import { cn } from "@/lib/utils"
+
+function Label({
+  className,
+  ...props
+}: React.ComponentProps<typeof LabelPrimitive.Root>) {
+  return (
+    <LabelPrimitive.Root
+      data-slot="label"
+      className={cn(
+        "flex items-center gap-2 text-sm leading-none font-medium select-none group-data-[disabled=true]:pointer-events-none group-data-[disabled=true]:opacity-50 peer-disabled:cursor-not-allowed peer-disabled:opacity-50",
+        className
+      )}
+      {...props}
+    />
+  )
+}
+
+export { Label }

--- a/src/app/components/Progress.tsx
+++ b/src/app/components/Progress.tsx
@@ -1,0 +1,23 @@
+// components/progress.tsx
+import React from "react";
+
+interface ProgressProps {
+  value: number;
+  step: number;
+  className?: string;
+}
+
+export const Progress: React.FC<ProgressProps> = ({
+  value,
+  step,
+  className = "",
+}) => {
+  return (
+    <div className={`relative w-full h-2 bg-gray-200 rounded ${className}`}>
+      <div
+        className="absolute top-0 left-0 h-2 bg-[#5f3dc4] rounded"
+        style={{ width: `${value}%` }}
+      ></div>
+    </div>
+  );
+};

--- a/src/app/components/Textarea.tsx
+++ b/src/app/components/Textarea.tsx
@@ -1,0 +1,18 @@
+import * as React from "react"
+
+import { cn } from "@/lib/utils"
+
+function Textarea({ className, ...props }: React.ComponentProps<"textarea">) {
+  return (
+    <textarea
+      data-slot="textarea"
+      className={cn(
+        "border-input placeholder:text-muted-foreground focus-visible:border-ring focus-visible:ring-ring/50 aria-invalid:ring-destructive/20 dark:aria-invalid:ring-destructive/40 aria-invalid:border-destructive dark:bg-input/30 flex field-sizing-content min-h-16 w-full rounded-md border bg-transparent px-3 py-2 text-base shadow-xs transition-[color,box-shadow] outline-none focus-visible:ring-[3px] disabled:cursor-not-allowed disabled:opacity-50 md:text-sm",
+        className
+      )}
+      {...props}
+    />
+  )
+}
+
+export { Textarea }

--- a/src/app/components/Toaster.tsx
+++ b/src/app/components/Toaster.tsx
@@ -1,0 +1,56 @@
+import React, { useEffect, useState } from "react";
+
+const Toaster = ({
+  message,
+  type,
+  onClose,
+  show,
+}: {
+  message: string;
+  type: "success" | "error";
+  onClose: () => void;
+  show: boolean;
+}) => {
+  const [exiting, setExiting] = useState(false);
+
+  useEffect(() => {
+    if (!show) {
+      setExiting(true);
+      const timer = setTimeout(() => {
+        setExiting(false);
+        onClose();
+      }, 400);
+      return () => clearTimeout(timer);
+    }
+    setExiting(false);
+  }, [show, onClose]);
+
+  return (
+    <div
+      className={`fixed top-6 right-6 z-50 px-4 py-3 rounded shadow-lg text-white transition-all duration-400 transform ${
+        type === "success" ? "bg-green-500" : "bg-red-500"
+      } ${
+        show && !exiting
+          ? "translate-x-0 opacity-100 pointer-events-auto"
+          : "translate-x-full opacity-0 pointer-events-none"
+      }`}
+      role="alert"
+    >
+      <div className="flex items-center">
+        <span className="mr-2 font-semibold">
+          {type === "success" ? "Success:" : "Error:"}
+        </span>
+        <span>{message}</span>
+        <button
+          className="ml-4 text-white/80 hover:text-white"
+          onClick={onClose}
+          aria-label="Close notification"
+        >
+          &times;
+        </button>
+      </div>
+    </div>
+  );
+};
+
+export default Toaster;

--- a/src/app/lib/context/ApplicationFormContext.tsx
+++ b/src/app/lib/context/ApplicationFormContext.tsx
@@ -1,0 +1,62 @@
+"use client";
+
+import React, { createContext, useContext, useState, ReactNode } from "react";
+
+type FormData = {
+  id_number?: string;
+  university?: string;
+
+  country?: string;
+  degree?: string;
+  codeforces?: string;
+  leetcode?: string;
+  github?: string;
+  essay_question_1?: string;
+  essay_question_2?: string;
+  resume?: File | null;
+};
+
+type ApplicationFormContextType = {
+  formData: FormData;
+  updateFormData: (newData: Partial<FormData>) => void;
+  resetFormData: () => void;
+};
+
+const ApplicationFormContext = createContext<
+  ApplicationFormContextType | undefined
+>(undefined);
+
+export const useApplicationForm = () => {
+  const context = useContext(ApplicationFormContext);
+  if (!context) {
+    throw new Error(
+      "useApplicationForm must be used within ApplicationFormProvider"
+    );
+  }
+  return context;
+};
+
+export const ApplicationFormProvider = ({
+  children,
+}: {
+  children: ReactNode;
+}) => {
+  const [formData, setFormData] = useState<FormData>({});
+
+  const updateFormData = (newData: Partial<FormData>) => {
+    setFormData((prev) => ({
+      ...prev,
+      ...newData,
+    }));
+  };
+
+  const resetFormData = () => setFormData({});
+
+  return (
+    <ApplicationFormContext.Provider
+      value={{ formData, updateFormData, resetFormData }}
+    >
+      {children}
+    </ApplicationFormContext.Provider>
+  );
+};

--- a/src/app/lib/redux/api/applicationApi.ts
+++ b/src/app/lib/redux/api/applicationApi.ts
@@ -1,0 +1,51 @@
+// lib/redux/api/applicationApi.ts
+import { createApi, fetchBaseQuery } from "@reduxjs/toolkit/query/react";
+
+export const applicationApi = createApi({
+  reducerPath: "applicationApi",
+  baseQuery: fetchBaseQuery({
+    baseUrl: "https://a2sv-application-platform-backend-team2.onrender.com/",
+    prepareHeaders: (headers) => {
+      if (typeof window !== "undefined") {
+        const token = "eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJzdWIiOiIxNTkyYWM3Yi00Y2E2LTQ0Y2YtOGUwZC0wMDdiODA5NzIwNDciLCJleHAiOjE3NTQ1Njk5NDYsInR5cGUiOiJhY2Nlc3MifQ.l2mzwLH2FbUEtoLTlxOdVcFdnwQ40KGv-EnVNgPFq3c";
+        if (token) {
+          headers.set("Authorization", `Bearer ${token}`);
+        }
+      }
+      return headers;
+    },
+  }),
+  endpoints: (builder) => ({
+    // ✅ GET /applications/my-status
+    getApplicationStatus: builder.query<any, void>({
+      query: () => "applications/my-status",
+    }),
+
+    // ✅ PATCH /manager/applications/:appId/assign
+    assignReviewer: builder.mutation<
+      void,
+      { appId: string; reviewer_id: string }
+    >({
+      query: ({ appId, reviewer_id }) => ({
+        url: `manager/applications/${appId}/assign`,
+        method: "PATCH",
+        body: { reviewer_id },
+      }),
+    }),
+
+    // ✅ POST /applications/
+    submitApplication: builder.mutation<any, FormData>({
+      query: (formData) => ({
+        url: "applications/",
+        method: "POST",
+        body: formData,
+      }),
+    }),
+  }),
+});
+
+export const {
+  useGetApplicationStatusQuery,
+  useAssignReviewerMutation,
+  useSubmitApplicationMutation,
+} = applicationApi;


### PR DESCRIPTION
### Description  
Added the applicant form pages and supporting components to structure the multi-step application process. This includes reusable UI components (`Card`, `Input`, `Label`, etc.), form state management via context, and API integration for submitting applications.  
This change is necessary to support applicant registration and form submission within the platform.

### Related Issue  
Closes #  

### How to Test  
1. Check out this branch.  
2. Run `npm install`.  
3. Navigate to `/auth/signup/applicant/application/personal-info`.  
4. Fill in the form and go through each step.  
5. Confirm that data is preserved across steps and the final submission hits the backend `/applications/` endpoint.  

### Screenshots (if applicable)  
<img width="1184" height="824" alt="image" src="https://github.com/user-attachments/assets/20112d45-0967-499a-9f13-f94891f279e8" />
<img width="1229" height="831" alt="image" src="https://github.com/user-attachments/assets/ea931092-cd70-4c7a-bf9a-6eafe1827ebb" />
<img width="1034" height="867" alt="image" src="https://github.com/user-attachments/assets/ab8a1b39-6aa7-4660-a9d3-6d2b0dcf1101" />

