### PR TITLE
fix: reload on timelinecard

### DIFF
--- a/src/app/components/TimeLinecard.tsx
+++ b/src/app/components/TimeLinecard.tsx
@@ -220,12 +220,15 @@ const TimeLineCard = () => {
                             setIsDeleting(true);
                             deleteApplication(application.data.id)
                               .unwrap()
-                              .then(() =>
+                              .then(() => {
                                 showToast(
                                   "success",
                                   "Application deleted successfully"
-                                )
-                              )
+                                );
+                                setTimeout(() => {
+                                  window.location.reload();
+                                }, 1500);
+                              })
                               .catch(() =>
                                 showToast("error", "Error deleting application")
                               )
@@ -250,12 +253,16 @@ const TimeLineCard = () => {
                             setIsSubmitting(true);
                             submitApplication(application.data.id)
                               .unwrap()
-                              .then(() =>
+                              .then(() => {
                                 showToast(
                                   "success",
                                   "Application submitted successfully"
-                                )
-                              )
+                                );
+
+                                setTimeout(() => {
+                                  window.location.reload();
+                                }, 1500);
+                              })
                               .catch(() =>
                                 showToast(
                                   "error",


### PR DESCRIPTION
### Description
Updated the `TimeLineCard` component to trigger a full page reload after successfully submitting or deleting an application. A `setTimeout` of 1.5 seconds was added to both actions to allow the success toast message to display before the reload. This ensures the timeline reflects the latest application state from the backend and prevents stale data from being shown.
